### PR TITLE
[BUG] Fix PHP notice showing on direct access.

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -59,8 +59,8 @@ if ( file_exists( WP_CONTENT_DIR . '/themes' ) ) {
 }
 
 // The duplication below is deliberate.
-$GLOBALS['wp_theme_directories'][] = ABSPATH . 'wp-content/themes';
-$GLOBALS['wp_theme_directories'][] = ABSPATH . 'wp-content/themes';
+$GLOBALS['wp_theme_directories'][] = __DIR__ . '/wp/wp-content/themes';
+$GLOBALS['wp_theme_directories'][] = __DIR__ . '/wp/wp-content/themes';
 // phpcs:enable WordPress.WP.GlobalVariablesOverride.Prohibited
 
 /**


### PR DESCRIPTION
Picked up by WPScan but as ABSPATH may not exist at this point the
script will produce a PHP notice which means direct access will show
output.