### PR TITLE
[FEATURE] Make use of dependabot ignore on some deps.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
         open-pull-requests-limit: 10
         commit-message:
             prefix: "[DEPS]"
+        ignore:
+            # Ignore PHPUnit major updates as WordPress only supports version 7 and below.
+            - dependency-name: "phpunit/phpunit"
+              update-types: ["version-update:semver-major"]
+
     # Monorepo builder tool.
     -   package-ecosystem: composer
         directory: "/tools/monorepo-builder"
@@ -36,6 +41,8 @@ updates:
         open-pull-requests-limit: 10
         commit-message:
             prefix: "[SETUP]"
+        ignore:
+            - update-types: ["version-update:semver-major"]
     # Docker blackfire image.
     -   package-ecosystem: docker
         directory: "/docker/blackfire"
@@ -45,6 +52,8 @@ updates:
         open-pull-requests-limit: 10
         commit-message:
             prefix: "[SETUP]"
+        ignore:
+            - update-types: ["version-update:semver-major"]
     # Docker database image.
     -   package-ecosystem: docker
         directory: "/docker/database"
@@ -54,6 +63,8 @@ updates:
         open-pull-requests-limit: 10
         commit-message:
             prefix: "[SETUP]"
+        ignore:
+            - update-types: ["version-update:semver-major"]
     # Docker mailhog image.
     -   package-ecosystem: docker
         directory: "/docker/mailhog"
@@ -63,6 +74,8 @@ updates:
         open-pull-requests-limit: 10
         commit-message:
             prefix: "[SETUP]"
+        ignore:
+            - update-types: ["version-update:semver-major"]
     # Docker memcached image.
     -   package-ecosystem: docker
         directory: "/docker/memcached"
@@ -72,6 +85,8 @@ updates:
         open-pull-requests-limit: 10
         commit-message:
             prefix: "[SETUP]"
+        ignore:
+            - update-types: ["version-update:semver-major"]
     # Docker nginx image.
     -   package-ecosystem: docker
         directory: "/docker/nginx"
@@ -81,6 +96,8 @@ updates:
         open-pull-requests-limit: 10
         commit-message:
             prefix: "[SETUP]"
+        ignore:
+            - update-types: ["version-update:semver-major"]
     # Docker node image.
     -   package-ecosystem: docker
         directory: "/docker/node"
@@ -90,6 +107,8 @@ updates:
         open-pull-requests-limit: 10
         commit-message:
             prefix: "[SETUP]"
+        ignore:
+            - update-types: ["version-update:semver-major"]
     # Docker styleguide image.
     -   package-ecosystem: docker
         directory: "/docker/styleguide"
@@ -99,3 +118,5 @@ updates:
         open-pull-requests-limit: 10
         commit-message:
             prefix: "[SETUP]"
+        ignore:
+            - update-types: ["version-update:semver-major"]


### PR DESCRIPTION
All our docker images we don't want to update to major versions.

For PHPUnit we want to stick with the current version (7) as newer
versions aren't supported by WordPress.