### PR TITLE
Fixes for PHP 7.4

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -50,6 +50,7 @@ fi
 
 envsubst \$PROJECT_NAME,\$STYLEGUIDE_DIR,\$DOCKER_NETWORK_NAME,\$PHP_VERSION < .env.dist > .env
 envsubst \$PROJECT_NAME,\$STYLEGUIDE_DIR < ./docker/app/.env.dist > ./docker/app/.env
+cp ./docker/blackfire/.env.dist ./docker/blackfire/.env
 
 if [ ! -f ./docker/database/.env ]; then
     cp ./docker/database/.env.dist ./docker/database/.env;

--- a/docker/app/php7.4/Dockerfile
+++ b/docker/app/php7.4/Dockerfile
@@ -10,8 +10,10 @@ RUN set -eux; \
     apt-get -y install git less zip unzip zlib1g-dev libicu-dev g++ libpng-dev libzip-dev libmagickwand-dev --no-install-recommends; \
     apt-get clean && apt-get autoremove; \
     rm -rf /var/lib/apt/lists/*; \
-    pecl install memcache-8.0 && docker-php-ext-enable memcache; \
-    pecl install imagick && docker-php-ext-enable imagick; \
+    pecl install memcache-4.0.5.2; \
+    pecl install imagick; \
+    docker-php-ext-enable memcache; \
+    docker-php-ext-enable imagick; \
     [ "${INSTALL_XDEBUG:-false}" = true ] && pecl install xdebug && docker-php-ext-enable xdebug; \
     docker-php-ext-configure intl; \
     docker-php-ext-install -j"$(nproc)" mysqli opcache zip intl gd


### PR DESCRIPTION
* switches Memcached version to 4.0.5.2 for PHP 7.4
* explicitly copy Blackfire environment variables file