### PR TITLE
Resolve bool error in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
             args:
                 USER_ID: ${USER_ID:-0}
                 GROUP_ID: ${GROUP_ID:-0}
-                INSTALL_XDEBUG: true
+                INSTALL_XDEBUG: 'true'
         env_file:
             - ./docker/app/.env
         volumes:


### PR DESCRIPTION
Running `bin/install my-project` currently returns the following error:

> ERROR: The Compose file './docker-compose.yml' is invalid because:
> services.app_xdebug.build.args contains true, which is an invalid type, it should be a string, number, or a null

Using a string resolves the issue