### PR TITLE
Remove deprecated constructor argument from symfony/dotenv

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,7 +8,8 @@ $root_dir = dirname( __DIR__, 1 );
 require_once $root_dir . '/wp-content/vendor/autoload.php';
 
 if ( is_readable( __DIR__ . '/.env' ) ) {
-	$dotenv = new Dotenv( true );
+	$dotenv = new Dotenv();
+	$dotenv->usePutenv( true );
 	$dotenv->load( __DIR__ . '/.env' );
 }
 


### PR DESCRIPTION
`symfony/dotenv` has changed the constructor arguments in v6 (deprecated in v5).
https://github.com/symfony/dotenv/blob/5.1/Dotenv.php#L49

This PR updates the initialisation to remove the deleted boolean value in the constructor and adds a call to `usePutEnv` in order to ensure PHPUnit is able to correctly load appropriate variables.
