### PR TITLE
Update wp fixtures to use forked version for compatibility with PHP 8.1

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -117,7 +117,7 @@ bin/docker/wp dictator impose site-state.yml;
 
 echo 'Setting up fixtures...'
 
-bin/docker/wp package install hellonico/wp-cli-fixtures;
+bin/docker/wp package install boxuk/wp-cli-fixtures;
 bin/docker/wp fixtures load;
 
 echo 'Flushing cache...'


### PR DESCRIPTION
There is an issue we’re facing in upgrading to PHP 8.1 with WP CLI Fixtures.

This occurs on PHP 8.1 (and now confirmed on PHP 8.0) when running wp fixtures load. The error we’re getting is:

Fatal error: Declaration of Hellonico\Fixtures\Provider\Picsum::imageUrl($width = 640, $height = 480, $filters = [],
 $format = 'jpg', $unused = false, $unused_ = false) must be compatible with Faker\Provider\Image::imageUrl($width = 640, 
$height = 480, $category = null, $randomize = true, $word = null, $gray = false, $format = 'png') 
in /var/www/.wp-cli/packages/vendor/hellonico/wp-cli-fixtures/src/Provider/Picsum.php on line 19
Taking a look at [Picsum.php](https://github.com/nlemoine/wp-cli-fixtures/blob/main/src/Provider/Picsum.php#L55), it has a different number of parameters to the parent method in [Image.php](https://github.com/FakerPHP/Faker/blob/main/src/Faker/Provider/Image.php#L46)

Changing Picsum.php to add the additional parameter gets it working again.

It seems the interface of the Faker\Provider\Image::imageUrl() function was changed in version 1.20.0 (https://github.com/FakerPHP/Faker/blob/main/src/Faker/Provider/Image.php) - and at the very bottom of the Faker PR someone comments that it's broken Backwards Compatiblity: (https://github.com/FakerPHP/Faker/pull/473).
We're finding that it's only PHP 8.x that is reporting this compatibility error (due to increased PHP 8 type checking - see the section on Contravariance in (https://php.watch/versions/8.0/lsp-errors)).

The Faker reference is in wp-cli-fixtures' composer.json: https://github.com/nlemoine/wp-cli-fixtures/blob/main/composer.json:

"require": {
  "php": "^7.3 || ^8.0",
  "fakerphp/faker": "^1.13",
  "nelmio/alice": "^3.8",
  "wp-cli/wp-cli": "^2.4"
 },
 
 This PR updates `install.sh` to use our forked repository until the PR on the nlemoine/wp-cli-fixtures repo can be merged.