### PR TITLE
[SETUP] Upgrade Mailhog

### DIFF
--- a/docker/app/msmtp-config/msmtprc
+++ b/docker/app/msmtp-config/msmtprc
@@ -1,0 +1,8 @@
+defaults
+
+account mailhog
+host mailhog
+port 1025
+from %U@%H
+
+account default: mailhog

--- a/docker/app/php-config/php.ini
+++ b/docker/app/php-config/php.ini
@@ -17,4 +17,4 @@ realpath_cache_ttl=14400
 
 cgi.fix_pathinfo = 0;
 
-sendmail_path = "/usr/bin/mhsendmail --smtp-addr=mailhog:1025"
+sendmail_path = "/usr/bin/msmtp -t"

--- a/docker/app/php8.0/Dockerfile
+++ b/docker/app/php8.0/Dockerfile
@@ -7,7 +7,7 @@ ARG INSTALL_XDEBUG
 # Do all apt-get installs on one line so they are installed on the same layer
 RUN set -eux; \
     apt-get -y update; \
-    apt-get -y install git less zip unzip zlib1g-dev libicu-dev g++ libpng-dev libzip-dev libmagickwand-dev --no-install-recommends; \
+    apt-get -y install git less zip unzip zlib1g-dev libicu-dev g++ libpng-dev libzip-dev libmagickwand-dev msmtp --no-install-recommends; \
     apt-get clean && apt-get autoremove; \
     rm -rf /var/lib/apt/lists/*; \
     pecl install memcache-8.0 && docker-php-ext-enable memcache; \
@@ -26,6 +26,12 @@ COPY --from=wordpress:cli-2.6.0-php8.0 /usr/local/bin/wp /usr/local/bin/wp
 RUN set -eux; \
     curl -sSLo /usr/bin/mhsendmail https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64; \
     chmod ugo+x /usr/bin/mhsendmail
+
+# Configure MSMTP
+COPY ./msmtp-config/msmtprc /etc/msmtprc
+RUN set -eux; \
+    chmod 600 /etc/msmtprc; \
+    chown www-data:www-data /etc/msmtprc
 
 # Blackfire
 # https://blackfire.io/docs/integrations/docker/php-docker

--- a/docker/app/php8.1/Dockerfile
+++ b/docker/app/php8.1/Dockerfile
@@ -7,7 +7,7 @@ ARG INSTALL_XDEBUG
 # Do all apt-get installs on one line so they are installed on the same layer
 RUN set -eux; \
     apt-get -y update; \
-    apt-get -y install git less zip unzip zlib1g-dev libicu-dev g++ libpng-dev libzip-dev libmagickwand-dev --no-install-recommends; \
+    apt-get -y install git less zip unzip zlib1g-dev libicu-dev g++ libpng-dev libzip-dev libmagickwand-dev msmtp --no-install-recommends; \
     apt-get clean && apt-get autoremove; \
     rm -rf /var/lib/apt/lists/*; \
     pecl install memcache-8.0 && docker-php-ext-enable memcache; \
@@ -22,10 +22,11 @@ COPY --from=composer:2.2.3 /usr/bin/composer /usr/local/bin/composer
 # WP-CLI
 COPY --from=wordpress:cli-2.6.0-php8.1 /usr/local/bin/wp /usr/local/bin/wp
 
-# MhSendmail
+# Configure MSMTP
+COPY ./msmtp-config/msmtprc /etc/msmtprc
 RUN set -eux; \
-    curl -sSLo /usr/bin/mhsendmail https://github.com/mailhog/mhsendmail/releases/download/v0.2.0/mhsendmail_linux_amd64; \
-    chmod ugo+x /usr/bin/mhsendmail
+    chmod 600 /etc/msmtprc; \
+    chown www-data:www-data /etc/msmtprc
 
 # Blackfire
 # https://blackfire.io/docs/integrations/docker/php-docker

--- a/docker/mailhog/Dockerfile
+++ b/docker/mailhog/Dockerfile
@@ -1,1 +1,5 @@
-FROM mailhog/mailhog:v1.0.1
+FROM golang:1.20
+
+RUN go install github.com/mailhog/MailHog@latest
+EXPOSE 1025 8025
+ENTRYPOINT ["MailHog"]


### PR DESCRIPTION
Upgrades Mailhog to use a version supported by modern chip architecture (specifically Apple Silicon)

Changes taken entirely from @jdamner's work on the OKdo project: https://github.com/boxuk/okdo/commit/19230e11658bc7791a8abe7efa3170757575818a