### PR TITLE
Skip mu-plugins on initial install

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -99,12 +99,25 @@ if [ ! -z "${STYLEGUIDE_DIR}" ]; then
     bin/docker/styleguide/yarn encore dev;
 fi
 
+# mu-plugins can interfere with the initial installation process, rewrite the directory to disable them temporarily
+mv wp-content/mu-plugins wp-content/mu-plugins-disabled
+
+# Add a trap to always move the directory back to it's original state, this covers:
+# - Normal termination (EXIT)
+# - Interrupted (INT)
+# - Killed (TERM)
+# - Hangup (HUP)
+trap '[ -d wp-content/mu-plugins-disabled ] && mv wp-content/mu-plugins-disabled wp-content/mu-plugins' EXIT INT TERM HUP
+
 echo 'Installing WordPress...';
 
 until bin/docker/wp core install --url="${WP_HOME}" --title="${PROJECT_NAME}" --admin_user=admin --admin_email=boxuk@example.com --skip-email;
 do
     echo 'Waiting for the database...';
 done
+
+# Manually move the directory back after the installation
+mv wp-content/mu-plugins-disabled wp-content/mu-plugins
 
 echo 'Emptying site...';
 


### PR DESCRIPTION
In a developed repo with mu-plugins it's very rare that a developer or plugin author will consider the use case of WP CLI running `wp install` for the first time. This can often break automated setup particularly with multisite based conditionals.

It is not possible to instruct WP CLI to skip mu-plugins as it is with `--skip-plugins`, and it's common that to avoid initial install we rename the mu-plugin folder as a whole.

This applies that temporary rewrite on initial setup, and adds a trap so that should the setup script exit, the developer should never have to manually rename folders, or intervene with the automation.

**How to test**

1. Pull down the repo
2. Create an mu-plugin of test.php
3. Add the code:
```
// Trigger a fatal error
trigger_error("Mimic an error thrown by unmet conditional, or uninitialised WP dependency", E_USER_ERROR);
```
4. Run the automated install `bin/install`
5. At the stage of "Installing WordPress..." you will get: `Error: There has been a critical error on this website.Learn more about troubleshooting WordPress. There has been a critical error on this website.`

Repeat this test with this branch, ensuring to start with a blank Docker config and this error will be bypassed.