### PR TITLE
[REFACTOR] Improvements to the way Docker commands are run

### DIFF
--- a/bin/docker/clearcache
+++ b/bin/docker/clearcache
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker-compose exec --user www-data app ./bin/clearcache "$@";
+bin/docker/php ./bin/clearcache "$@";

--- a/bin/docker/composer
+++ b/bin/docker/composer
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker-compose exec -T --user www-data app php -d memory_limit=1G /usr/local/bin/composer "$@"
+bin/docker/php /usr/local/bin/composer "$@"

--- a/bin/docker/nodejs
+++ b/bin/docker/nodejs
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# if node is already running, use it
+
+if [ "$(docker inspect -f '{{.State.Running}}' nodejs 2>/dev/null)" = "true" ]; then
+  docker exec -it nodejs "$@"
+else
+  docker compose run --rm nodejs "$@"
+fi

--- a/bin/docker/npm
+++ b/bin/docker/npm
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker compose -f docker-compose.yml run -T --rm --workdir /usr/src/app nodejs npm "$@"
+bin/docker/nodejs npm "$@"

--- a/bin/docker/php
+++ b/bin/docker/php
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# If container is running, exec inside, else run a new container
+if [ "$(docker inspect -f '{{.State.Running}}' app 2>/dev/null)" = "true" ]; then
+    docker-compose exec --user www-data app php -d memory_limit=1G "$@"
+else
+    docker-compose run --rm --user www-data app php -d memory_limit=1G "$@"
+fi

--- a/bin/docker/phpstan
+++ b/bin/docker/phpstan
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 
 bin/docker/composer run phpstan "$@"

--- a/bin/docker/wp
+++ b/bin/docker/wp
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker-compose exec --user www-data app php -d memory_limit=1G /usr/local/bin/wp "$@"
+bin/docker/php /usr/local/bin/wp "$@"

--- a/compose.yml
+++ b/compose.yml
@@ -29,13 +29,6 @@ services:
     extra_hosts:
       - host.docker.internal:host-gateway
       - '${LOOPBACK_HOST_NAME}:192.168.35.10' # IP should match the IP address set for nginx below
-    depends_on:
-      database:
-          condition: service_healthy
-      mailpit:
-          condition: service_healthy
-      memcached:
-          condition: service_healthy
     healthcheck:
       test: ["CMD", "php", "-v"]
       interval: 10s
@@ -58,9 +51,6 @@ services:
     extra_hosts:
       - host.docker.internal:host-gateway
       - '${LOOPBACK_HOST_NAME}:192.168.35.10' # IP should match the IP address set for nginx below
-    depends_on:
-      app:
-        condition: service_healthy
     healthcheck:
       test: ["CMD", "php", "-v"]
       interval: 10s
@@ -83,6 +73,12 @@ services:
         condition: service_healthy
       app_xdebug:
         condition: service_healthy
+      database:
+          condition: service_healthy
+      mailpit:
+          condition: service_healthy
+      memcached:
+          condition: service_healthy
     links:
       - app
       - app_xdebug
@@ -105,6 +101,7 @@ services:
 
   nodejs:
     build: docker/node
+    working_dir: /usr/src/app
     volumes:
       - '.:/usr/src/app:cached'
       - './node_modules:/usr/src/app/node_modules:delegated'


### PR DESCRIPTION
- Refactors docker commands to use a shared root command for each container. 
- Refactors the commands to use the running instance if available, or if not just to spin up an instance to run then finish. This allows commands such as composer to be run _without_ needing to spin up the entire docker stack. 
- Fixes an issue that causes errors in the nodejs container if the workdir is not specified by setting default value in the compose file. 
- Renames the `docker-compose.yml` to `compose.yml` in line with newer docker guidelines. 