### PR TITLE
Remove blackfire, Enable Xdebug, Update images

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ bin/docker/wp user update admin --user_pass=your_password_here
 
 ## Features
 
-📕 - Fully [documented](https://boxuk.github.io/wp-project-skeleton/).
+📕 - Fully [documented](https://boxuk.github.io/wp-packages/docs/skeleton/).
 
 🐳 - Fully dockerized setup
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,14 @@ composer create-project boxuk/wp-project-skeleton my-project --stability=dev
 Install with the simple install script
 
 ```bash
-bin/install my-project
+bin/install --project=[project_name] --network=[docker_network_name] --php=[php_version]
 ```
+All arguments are optional.
+
+Defaults: 
+- Project Name = boxuk-wp-skeleton 
+- Network Name = boxuk-docker
+- PHP Version = 8.2
 
 > Note: This is an interactive command.
 
@@ -39,17 +45,17 @@ bin/docker/wp user update admin --user_pass=your_password_here
 
 ## Features
 
-📕 - Fully [documented](https://boxuk.github.io/wp-packages/).
+📕 - Fully [documented](https://boxuk.github.io/wp-project-skeleton/).
 
 🐳 - Fully dockerized setup
 
 📦 - Composer based plugin management
 
-🧠 - [Genius xDebug setup](https://strayobject.medium.com/php-docker-and-xdebug-with-no-performance-loss-261ad89efd6e)
+🧠 - Xdebug installed by default
 
-📋 - [Dictator](https://github.com/boxuk/dictator/) support for dictating state across environments
+📋 - Configurable state across environments (WIP)
 
-🪜 - Fixtures support using [wp-cli-fixtures](https://github.com/nlemoine/wp-cli-fixtures)
+🪜 - Customisable fixtures support using the WP CLI (WIP)
 
 🚩 - First class support for feature flags using [wp-feature-flags](https://github.com/boxuk/wp-feature-flags)
 

--- a/bin/docker/disable_blackfire
+++ b/bin/docker/disable_blackfire
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-docker-compose --profile profiling stop && docker-compose up -d --remove-orphans

--- a/bin/docker/enable_blackfire
+++ b/bin/docker/enable_blackfire
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-docker-compose stop && docker-compose --profile profiling up -d

--- a/bin/docker/php
+++ b/bin/docker/php
@@ -2,7 +2,7 @@
 
 # If container is running, exec inside, else run a new container
 if [ "$(docker inspect -f '{{.State.Running}}' app 2>/dev/null)" = "true" ]; then
-    docker-compose exec --user www-data app php -d memory_limit=1G "$@"
+    docker compose exec --user www-data app php -d memory_limit=1G "$@"
 else
-    docker-compose run --rm --user www-data app php -d memory_limit=1G "$@"
+    docker compose run --rm --user www-data app php -d memory_limit=1G "$@"
 fi

--- a/bin/docker/ssh
+++ b/bin/docker/ssh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker-compose exec --user www-data "$@" bash
+docker compose exec --user www-data "$@" bash

--- a/bin/docker/xdebug/composer
+++ b/bin/docker/xdebug/composer
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-bin/docker/xdebug/php /usr/local/bin/composer "$@"

--- a/bin/docker/xdebug/php
+++ b/bin/docker/xdebug/php
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-# If container is running, exec inside, else run a new container
-if [ "$(docker inspect -f '{{.State.Running}}' app_xdebug 2>/dev/null)" = "true" ]; then
-    docker-compose exec --user www-data app_xdebug php -d memory_limit=1G "$@"
-else
-    docker-compose run --rm --user www-data app_xdebug php -d memory_limit=1G "$@"
-fi

--- a/bin/docker/xdebug/phpcbf
+++ b/bin/docker/xdebug/phpcbf
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-bin/docker/xdebug/composer run phpcbf "$@"

--- a/bin/docker/xdebug/phpcs
+++ b/bin/docker/xdebug/phpcs
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-bin/docker/xdebug/composer run phpcs "$@"

--- a/bin/docker/xdebug/phpstan
+++ b/bin/docker/xdebug/phpstan
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-bin/docker/xdebug/composer run phpstan "$@"

--- a/bin/docker/xdebug/phpunit
+++ b/bin/docker/xdebug/phpunit
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-bin/docker/xdebug/composer run phpunit "$@"

--- a/bin/docker/xdebug/wp
+++ b/bin/docker/xdebug/wp
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-bin/docker/xdebug/php /usr/local/bin/wp "$@"

--- a/bin/install
+++ b/bin/install
@@ -59,7 +59,7 @@ fi
 
 echo 'Stopping any running containers...';
 
-docker-compose stop;
+docker compose stop;
 
 # Import .env files so we have access to env vars. docker/app/.env will override the root.
 . .env;
@@ -67,8 +67,8 @@ docker-compose stop;
 
 echo 'Building docker containers...';
 
-docker-compose build;
-docker-compose up -d;
+docker compose build;
+docker compose up -d;
 
 echo 'Running composer install...';
 
@@ -94,20 +94,6 @@ done
 # Manually move the directory back after the installation
 mv wp-content/mu-plugins-disabled wp-content/mu-plugins
 
-echo 'Emptying site...';
-
-bin/docker/wp site empty;
-
-echo 'Setting up state...';
-
-bin/docker/wp package install boxuk/dictator:@stable;
-bin/docker/wp dictator impose site-state.yml;
-
-echo 'Setting up fixtures...'
-
-bin/docker/wp package install hellonico/wp-cli-fixtures;
-bin/docker/wp fixtures load;
-
 echo 'Flushing cache...'
 bin/docker/wp cache flush;
 
@@ -132,6 +118,10 @@ read -s -p "Enter a password to setup WP admin account: " ADMIN_PASSWORD
 echo -e "\nSetting password...";
 bin/docker/wp user update admin --user_pass=$ADMIN_PASSWORD
 
+# Enable Xdebug
+echo 'Enabling Xdebug..';
+docker compose exec app bash -c "sed -i 's/xdebug.mode=Off/xdebug.mode=debug/' /usr/local/etc/php/conf.d/php.ini; exit;"
+docker compose restart app
 
 clear;
 # Art generated: https://patorjk.com/software/taag/#p=display&v=0&c=echo&f=Standard&t=Installation%0AComplete

--- a/compose.yml
+++ b/compose.yml
@@ -1,7 +1,7 @@
 services:
   # Build images for each container to allow for dependabot support, see: https://github.com/dependabot/dependabot-core/issues/390
   database:
-    build: docker/database
+    image: mariadb:latest
     environment:
       MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-password}
       MYSQL_DATABASE: ${DB_NAME:-project}
@@ -10,7 +10,7 @@ services:
     ports:
       - '127.0.0.1:3307:3306' # always bind to 127.0.0.1 or 192.168.34.1 etc. Never bind to 0.0.0.0 unless you know what you are doing
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      test: [ "CMD", "healthcheck.sh", "--su-mysql", "--connect", "--innodb_initialized" ]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -22,32 +22,11 @@ services:
       args:
         USER_ID: ${USER_ID:-0}
         GROUP_ID: ${GROUP_ID:-0}
+        XDEBUG_VERSION: '3.4.1'
     env_file:
       - ./docker/app/.env
     volumes:
-      - '.:/var/www/html:cached'
-    extra_hosts:
-      - host.docker.internal:host-gateway
-      - '${LOOPBACK_HOST_NAME}:192.168.35.10' # IP should match the IP address set for nginx below
-    healthcheck:
-      test: ["CMD", "php", "-v"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
-
-  app_xdebug:
-    build:
-      context: docker/app
-      dockerfile: php${PHP_VERSION:-8.2}/Dockerfile
-      args:
-        USER_ID: ${USER_ID:-0}
-        GROUP_ID: ${GROUP_ID:-0}
-        INSTALL_XDEBUG: 'true'
-        XDEBUG_VERSION: '3.2.2'
-    env_file:
-      - ./docker/app/.env
-    volumes:
-      - '.:/var/www/html:cached'
+      - '.:/var/www/html'
     extra_hosts:
       - host.docker.internal:host-gateway
       - '${LOOPBACK_HOST_NAME}:192.168.35.10' # IP should match the IP address set for nginx below
@@ -60,7 +39,7 @@ services:
   nginx:
     build: docker/nginx
     volumes:
-      - '.:/var/www/html:cached'
+      - '.:/var/www/html'
       - './docker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf'
       - './docker/nginx/conf:/etc/nginx/conf.d/conf'
       - './docker/nginx/insecure_https.crt:/etc/pki/tls/certs/insecure_https.crt:delegated'
@@ -71,8 +50,6 @@ services:
     depends_on:
       app:
         condition: service_healthy
-      app_xdebug:
-        condition: service_healthy
       database:
           condition: service_healthy
       mailpit:
@@ -81,7 +58,6 @@ services:
           condition: service_healthy
     links:
       - app
-      - app_xdebug
     networks:
       default:
         aliases:

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "roots/bedrock-autoloader": "^1.0",
         "roots/wordpress-core-installer": "^2.0",
         "roots/wordpress-no-content": "^6.4",
-        "symfony/dotenv": "^6.0 || ^7.0",
+        "symfony/dotenv": "^7.0",
         "wp-cli/scaffold-command": "^2.0",
         "wp-cli/wp-cli": "^2.9",
         "wpackagist-plugin/query-monitor": "^3.5"

--- a/docker/app/.env.dist
+++ b/docker/app/.env.dist
@@ -1,5 +1,5 @@
 PHP_XDEBUG_ENABLED=1
-PHP_XDEBUG_REMOTE_PORT=9002
+PHP_XDEBUG_REMOTE_PORT=9003
 # Xdebug remote host likely 192.168.35.1 if not using docker or possibly on linux
 PHP_XDEBUG_REMOTE_HOST=host.docker.internal
 PHP_XDEBUG_IDKEY=wordpress

--- a/docker/app/php-config/php.ini
+++ b/docker/app/php-config/php.ini
@@ -18,3 +18,34 @@ realpath_cache_ttl=14400
 cgi.fix_pathinfo = 0;
 
 sendmail_path="sendmail --smtp-addr=mailpit:1025"
+
+[xDebug]
+; Generic
+xdebug.mode=Off
+xdebug.start_with_request=yes
+xdebug.discover_client_host=1
+xdebug.client_host=${PHP_XDEBUG_REMOTE_HOST}
+xdebug.client_port=${PHP_XDEBUG_REMOTE_PORT}
+xdebug.idekey=${PHP_XDEBUG_IDKEY}
+xdebug.max_nesting_level=512
+
+; Display
+xdebug.scream=0
+xdebug.force_display_errors=0
+xdebug.force_error_reporting=0
+xdebug.var_display_max_children=512
+xdebug.var_display_max_data=512
+xdebug.var_display_max_depth=5
+
+; Function/Stack Traces
+xdebug.collect_assignments=0
+xdebug.collect_return=0
+xdebug.show_exception_trace=0
+xdebug.show_local_vars=0
+xdebug.trace_format=0
+xdebug.trace_options=0
+xdebug.trace_output_name=trace.%c
+
+; Profiling
+xdebug.profiler_append=0
+xdebug.profiler_output_name=cachegrind.out.%p

--- a/docker/app/php-config/xdebug.ini
+++ b/docker/app/php-config/xdebug.ini
@@ -1,9 +1,0 @@
-[xdebug]
-xdebug.max_nesting_level=256
-
-xdebug.client_host=${PHP_XDEBUG_REMOTE_HOST}
-xdebug.client_port=${PHP_XDEBUG_REMOTE_PORT}
-xdebug.idekey=${PHP_XDEBUG_IDKEY}
-
-xdebug.mode=debug
-xdebug.start_with_request=yes

--- a/docker/app/php8.2/Dockerfile
+++ b/docker/app/php8.2/Dockerfile
@@ -2,7 +2,6 @@ FROM php:8.2.27-fpm
 
 ARG USER_ID
 ARG GROUP_ID
-ARG INSTALL_XDEBUG
 ARG XDEBUG_VERSION
 
 # Do all apt-get installs on one line so they are installed on the same layer
@@ -14,12 +13,12 @@ RUN set -eux; \
     pecl install memcache-8.0 && docker-php-ext-enable memcache; \
     pecl install imagick && docker-php-ext-enable imagick; \
     pecl install pcov && docker-php-ext-enable pcov; \
-    [ "${INSTALL_XDEBUG:-false}" = true ] && pecl install xdebug-${XDEBUG_VERSION} && docker-php-ext-enable xdebug; \
+    pecl install xdebug-${XDEBUG_VERSION} && docker-php-ext-enable xdebug; \
     docker-php-ext-configure intl; \
     docker-php-ext-install -j"$(nproc)" mysqli opcache zip intl gd
 
 # Composer
-COPY --from=composer:2.6.5 /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 # WP-CLI - https://hub.docker.com/_/wordpress/tags?page=1&name=cli
 COPY --from=wordpress:cli-2.9.0-php8.2 /usr/local/bin/wp /usr/local/bin/wp

--- a/docker/app/php8.3/Dockerfile
+++ b/docker/app/php8.3/Dockerfile
@@ -2,7 +2,6 @@ FROM php:8.3.15-fpm
 
 ARG USER_ID
 ARG GROUP_ID
-ARG INSTALL_XDEBUG
 ARG XDEBUG_VERSION
 
 # Do all apt-get installs on one line so they are installed on the same layer
@@ -14,12 +13,12 @@ RUN set -eux; \
     pecl install memcache-8.0 && docker-php-ext-enable memcache; \
     pecl install imagick && docker-php-ext-enable imagick; \
     pecl install pcov && docker-php-ext-enable pcov; \
-    [ "${INSTALL_XDEBUG:-false}" = true ] && pecl install xdebug-${XDEBUG_VERSION} && docker-php-ext-enable xdebug; \
+    pecl install xdebug-${XDEBUG_VERSION} && docker-php-ext-enable xdebug; \
     docker-php-ext-configure intl; \
     docker-php-ext-install -j"$(nproc)" mysqli opcache zip intl gd
 
 # Composer
-COPY --from=composer:2.6.5 /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 # WP-CLI - https://hub.docker.com/_/wordpress/tags?page=1&name=cli
 COPY --from=wordpress:cli-2.9.0-php8.3 /usr/local/bin/wp /usr/local/bin/wp

--- a/docker/database/Dockerfile
+++ b/docker/database/Dockerfile
@@ -1,1 +1,0 @@
-FROM mariadb:11.6.2

--- a/docker/mailpit/Dockerfile
+++ b/docker/mailpit/Dockerfile
@@ -1,1 +1,1 @@
-FROM axllent/mailpit:v1.21.8
+FROM axllent/mailpit:latest

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -8,7 +8,6 @@ resolver 127.0.0.11;
 # Idea from https://github.com/developersalliance/magento2-dockergento/blob/master/config/dockergento/nginx/conf/default.conf
 map $cookie_XDEBUG_SESSION $fastcgi_pass {
     default app;
-    wordpress app_xdebug;
 }
 
 server {

--- a/tests/phpintegration-bootstrap.php
+++ b/tests/phpintegration-bootstrap.php
@@ -6,7 +6,7 @@
 declare ( strict_types=1 );
 
 $root = dirname( __DIR__ );
-$composer = json_decode( file_get_contents( $root . '/composer.json' ), true, 512, JSON_THROW_ON_ERROR );
+$composer = json_decode( (string) file_get_contents( $root . '/composer.json' ), true, 512, JSON_THROW_ON_ERROR );
 $vendor = $composer['config']['vendor-dir'];
 $tests_dir = getenv( 'WP_PHPUNIT__DIR' );
 

--- a/tests/phpintegration-wp-config.php
+++ b/tests/phpintegration-wp-config.php
@@ -5,7 +5,7 @@ declare ( strict_types=1 );
 use Symfony\Component\Dotenv\Dotenv;
 
 $root = dirname( __DIR__ );
-$composer = json_decode( file_get_contents( $root . '/composer.json' ), true, 512, JSON_THROW_ON_ERROR );
+$composer = json_decode( (string) file_get_contents( $root . '/composer.json' ), true, 512, JSON_THROW_ON_ERROR );
 $vendor = $composer['config']['vendor-dir'];
 
 require_once $vendor . '/autoload.php';

--- a/wp-config.php
+++ b/wp-config.php
@@ -44,7 +44,7 @@ define( 'WP_HOME', $_ENV['WP_HOME'] );
 define( 'WP_SITEURL', $_ENV['WP_HOME'] );
 
 define( 'WP_CONTENT_URL', $_ENV['WP_HOME'] . '/wp-content' );
-define( 'WP_CONTENT_DIR', __DIR__ . '/wp-content' );
+define( 'WP_CONTENT_DIR', __DIR__ . '/../wp-content' );
 
 define( 'WP_ENVIRONMENT_TYPE', $_ENV['WP_ENVIRONMENT_TYPE'] );
 
@@ -59,8 +59,8 @@ if ( file_exists( WP_CONTENT_DIR . '/themes' ) ) {
 }
 
 // The duplication below is deliberate.
-$GLOBALS['wp_theme_directories'][] = __DIR__ . '/wp/wp-content/themes';
-$GLOBALS['wp_theme_directories'][] = __DIR__ . '/wp/wp-content/themes';
+$GLOBALS['wp_theme_directories'][] = __DIR__ . '/wp-content/themes';
+$GLOBALS['wp_theme_directories'][] = __DIR__ . '/wp-content/themes';
 // phpcs:enable WordPress.WP.GlobalVariablesOverride.Prohibited
 
 /**


### PR DESCRIPTION
Replaces deprecated docker commands
Enables Xdebug by default
Uses Xdebug in main container
Removes site empty command
Removes deprecated packages - dictator and wp-cli-fixtures
Updates MariaDB to use official, latest image
Replaces (now) missing healthcheck on MariaDB container
Updates Xdebug
Updates Mailpit
Removes Blackfire
Updates Readme