### PR TITLE
Use latest cli version

### DIFF
--- a/docker/app/php8.2/Dockerfile
+++ b/docker/app/php8.2/Dockerfile
@@ -20,7 +20,7 @@ RUN set -eux; \
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 # WP-CLI - https://hub.docker.com/_/wordpress/tags?page=1&name=cli
-COPY --from=wordpress:cli-2.9.0-php8.2 /usr/local/bin/wp /usr/local/bin/wp
+COPY --from=wordpress:cli-php8.2 /usr/local/bin/wp /usr/local/bin/wp
 
 # Set groups and user when on linux
 RUN set -eux; \

--- a/docker/app/php8.3/Dockerfile
+++ b/docker/app/php8.3/Dockerfile
@@ -20,7 +20,7 @@ RUN set -eux; \
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 
 # WP-CLI - https://hub.docker.com/_/wordpress/tags?page=1&name=cli
-COPY --from=wordpress:cli-2.9.0-php8.3 /usr/local/bin/wp /usr/local/bin/wp
+COPY --from=wordpress:cli-php8.3 /usr/local/bin/wp /usr/local/bin/wp
 
 # Set groups and user when on linux
 RUN set -eux; \


### PR DESCRIPTION
Fixes WP Cli not being copied
Resolves vulns from 2.9
Always uses latest cli version